### PR TITLE
feature/better writing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ While in the root of the envim directory [run in a new shell containing the buil
 ```sh
 nix develop
 ```
+
+### Grammar support with LSP
+
+The [`ltex` LSP server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ltex) supports language models that can be used to suggest fixes for more nuanced grammar issues. These models are rather large, so I opted to exclude packaging it directly. While the model is missing, the ltex lsp server still works, but to get more capabilities you can download [ngrams](https://dev.languagetool.org/finding-errors-using-n-gram-data.html) and unzip the model at `~/models/ngrams`.
+
+> Unzip it and put it in its own directory named en, de, fr, or es, depending on the language. The path you need to set in the next step is the directory that the en etc. directory is in, not that directory itself.
+
+So, in my case I have `~/models/ngrams/en`.

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -35,6 +35,7 @@
     tree-sitter
     shfmt
     helm-ls # Helm LSP
+    ltex-ls # Grammar and spelling in markup files
 
     # Terraform LSP packages
     terraform-ls

--- a/nvim/lua/plugins/lsp/servers/init.lua
+++ b/nvim/lua/plugins/lsp/servers/init.lua
@@ -102,6 +102,7 @@ M.setup = function()
     settings = {
       ltex = {
         language = "en",
+        flags = { debounce_text_changes = 300 },
         -- additionalRules = {
         --   languageModel = "~/ngrams/",
         -- },

--- a/nvim/lua/plugins/lsp/servers/init.lua
+++ b/nvim/lua/plugins/lsp/servers/init.lua
@@ -103,9 +103,9 @@ M.setup = function()
       ltex = {
         language = "en",
         flags = { debounce_text_changes = 300 },
-        -- additionalRules = {
-        --   languageModel = "~/ngrams/",
-        -- },
+        additionalRules = {
+          languageModel = "~/models/ngrams/",
+        },
       },
     },
   }))

--- a/nvim/lua/plugins/lsp/servers/init.lua
+++ b/nvim/lua/plugins/lsp/servers/init.lua
@@ -96,6 +96,18 @@ M.setup = function()
 
   -- Markdown
   require("lspconfig").marksman.setup(config({}))
+
+  -- Grammar and spelling markup languages (includes markdown)
+  require("lspconfig").ltex.setup(config({
+    settings = {
+      ltex = {
+        language = "en",
+        -- additionalRules = {
+        --   languageModel = "~/ngrams/",
+        -- },
+      },
+    },
+  }))
 end
 
 return M


### PR DESCRIPTION
# Description

Go beyond just spellcheck to get grammar suggestions and quick fixes for English in various markup formats, including markdown. This uses [ngram data](https://languagetool.org/download/ngram-data/) which needs to be downloaded separately and saved to `~/models/ngrams` (somewhat arbitrary choice to use this path).

## Changes

- setups up ltex lsp
- sets ltex debounce on text change
- sets ltex language model path
- explains how to use ltex language model
